### PR TITLE
Update eslint, react-scripts in order to fix npm vuls

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-NODE_PATH=src/

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "baseUrl": ".",
+    "baseUrl": "src",
     "jsx": "react",
     "paths": {
       "*": ["src/*"]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "react-dom": "^16.8.2",
     "react-i18next": "^10.6.0",
     "react-router-dom": "^5.0.0",
-    "react-scripts": "2.1.8",
+    "react-scripts": "3.0.0",
     "styled-components": "^4.1.3"
   },
   "scripts": {
@@ -36,7 +36,7 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.11.2",
     "enzyme-to-json": "^3.3.5",
-    "eslint": "5.12.0",
+    "eslint": "5.16.0",
     "eslint-plugin-react": "^7.12.4",
     "jest-styled-components": "^6.3.1"
   },


### PR DESCRIPTION
# PR Details
During my local tests I found many npm vulns than I suppose that it should be updated. 

## Description
Original issue:

found 68 vulnerabilities (63 low, 5 high) in 37370 scanned packages
  68 vulnerabilities require semver-major dependency updates.

fixed:

update   "react-scripts": "2.1.8"  to  "react-scripts": "3.0.0"
update    "eslint": "5.12.0"  to "eslint": "5.16.0"

- [x] Bug fix (non-breaking change which fixes an issue)
