### PR TITLE
Fix workers and add coverage task

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --maxWorkers=3",
+    "test:coverage": "react-scripts test --watchAll=false --coverage --no-cache --logHeapUsage --silent --maxWorkers=2",
     "eject": "react-scripts eject",
     "eslint": "eslint --ext .jsx,.js src"
   },


### PR DESCRIPTION
# PR Details
This fix partial problem of memory leak when run tests in CI.

## Description
Currently with no limitation of workers, the jest requests extra virtual resources beyond existing physical resources.
With this, in several moments the CI stops to execute due to lack of resources in the machine.

Partial fixes limit the amount of resources to be used in the CI environment and also on your local machine.

The ideal task to run in the CI environment that validates the full coverage (when configured) is: `ǹpm run test: coverage`


## Types of changes
- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
