### PR TITLE
fix(npm): remove the eslint inference on lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --maxWorkers=3",
     "test:coverage": "react-scripts test --watchAll=false --coverage --no-cache --logHeapUsage --silent --maxWorkers=2",
-    "eslint": "eslint --ext .jsx,.js src",
+    "lint": "eslint --ext .jsx,.js src",
     "docs:dev": "docz dev",
     "docs:build": "docz build"
   },


### PR DESCRIPTION
# PR Details
Change command `eslint` to `lint`.

## Description
I wanted to remove the reference to eslint plugin.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
