### PR TITLE
docs(readme): add warning about npm issue with hoisted packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,10 @@ Step by step to get this up and running
 ### Install dependencies
 
 ```bash
-npm i
-```
-
-or via yarn:
-
-```bash
 yarn
 ```
 
 ### Start server
-
-```bash
-npm run start
-```
-
-or
 
 ```bash
 yarn start
@@ -48,7 +36,7 @@ yarn start
 
 These are some of patterns definitions to help us to keep a default configuration and front-end arquitecture.
 
-- NPM or Yarn? Your call.
+- NPM or Yarn? `npm` has a known issue with hoisted packages ([here](https://npm.community/t/packages-with-peerdependencies-are-incorrectly-hoisted/4794)), that is the reason we use `yarn`.
 - UI Kit library? Jump into [MaterialUI](https://material-ui.com)
 - Linter: If You don't use [Gandalf Lint](https://github.com/SoftboxLab/gandalf-lint), you shall not pass.
 - Do you want a component pattern? [Get here](src/containers/Home/index.jsx)


### PR DESCRIPTION
`npm` has a know issue with hoisted packages, so we started using `yarn` instead.
https://npm.community/t/packages-with-peerdependencies-are-incorrectly-hoisted/4794/3

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
