### PR TITLE
fix/rename-function-it

### DIFF
--- a/src/components/Loading/__tests__/Loading.test.js
+++ b/src/components/Loading/__tests__/Loading.test.js
@@ -3,10 +3,9 @@ import { shallow } from 'enzyme'
 import Loading from '..'
 
 describe('Loading', () => {
-test('should render', () => {
+  test('should render', () => {
     const component = shallow(<Loading />)
 
     expect(component).toMatchSnapshot()
   })
 })
-

--- a/src/components/Loading/__tests__/Loading.test.js
+++ b/src/components/Loading/__tests__/Loading.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme'
 import Loading from '..'
 
 describe('Loading', () => {
-  it('should render', () => {
+test('should render', () => {
     const component = shallow(<Loading />)
 
     expect(component).toMatchSnapshot()

--- a/src/components/Loading/__tests__/LoadingStyled.test.js
+++ b/src/components/Loading/__tests__/LoadingStyled.test.js
@@ -3,7 +3,7 @@ import { mount } from 'enzyme'
 import LoadingStyled from '../style'
 
 describe('Loading styled', () => {
-  it('should render with width 100%', () => {
+  test('should render with width 100%', () => {
     const component = mount(<LoadingStyled />)
 
     expect(component).toHaveStyleRule('width', '100%')


### PR DESCRIPTION
# PR Details
rename functions to new pattern "test"

## Description
The call with name "test" is written in the official documentation of jest to follow the best practices I change the name to test.

[Jest Documentation](https://jestjs.io/docs/en/api
)