### PR TITLE
feature/use-props-component-to-render

### DIFF
--- a/src/containers/Main/index.jsx
+++ b/src/containers/Main/index.jsx
@@ -13,7 +13,7 @@ const Main = () => (
             key={route.path}
             path={route.path}
             exact={route.exact}
-            component={route.main}
+            component={route.component}
           />
         ))}
       </Switch>

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -5,7 +5,7 @@ const Home = lazy(() => import('containers/Home'))
 const route = [
   {
     path: '/',
-    main: Home,
+    component: Home,
     exact: true
   }
 ]


### PR DESCRIPTION
# PR Details
User props component to render the router.

## Description
The new versions of React Router do not use more "main" props to render a component. 

```
export interface RouteProps {
    location?: H.Location;
    component?: React.ComponentType<RouteComponentProps<any>> | React.ComponentType<any>;
    render?: (props: RouteComponentProps<any>) => React.ReactNode;
    children?: ((props: RouteChildrenProps<any>) => React.ReactNode) | React.ReactNode;
    path?: string | string[];
    exact?: boolean;
    sensitive?: boolean;
    strict?: boolean;
}
```
Documentation: [`React Router`](https://reacttraining.com/react-router/web/api/Route)
